### PR TITLE
fix: /member/find/password 에 헤더 추가

### DIFF
--- a/src/hooks/auth/useFindPassword.tsx
+++ b/src/hooks/auth/useFindPassword.tsx
@@ -12,7 +12,13 @@ const useFindPassword = (props: { email: string }) => {
       const data = { email: props.email };
       const res = await axios.post(
         `${process.env.REACT_APP_API}/member/find/password`,
-        data
+        data,
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+          },
+        }
       );
       alert(res.data);
       navigate('/login');


### PR DESCRIPTION
이메일 전송 안되는 406 에러
- 이메일 암호화되는 문제 발생